### PR TITLE
Support strings marked html_safe

### DIFF
--- a/anchored.gemspec
+++ b/anchored.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~> 5.10"
+  spec.add_development_dependency "activesupport", "~> 5.0"
 end

--- a/lib/anchored/linker.rb
+++ b/lib/anchored/linker.rb
@@ -35,7 +35,8 @@ module Anchored
     # Turns all urls into clickable links.  If a block is given, each url
     # is yielded and the result is used as the link text.
     def auto_link_urls(text, options = {})
-      text.gsub(AUTO_LINK_RE) do
+      # to_str is for SafeBuffer objects (text marked html_safe)
+      text.to_str.gsub(AUTO_LINK_RE) do
         match = Regexp.last_match
         href = match[0]
         scheme = match[1]

--- a/test/linker_test.rb
+++ b/test/linker_test.rb
@@ -266,9 +266,4 @@ class LinkerTest < Minitest::Test
   def auto_link(*args, &block)
     Anchored::Linker.auto_link(*args, &block)
   end
-
-  def generate_result(link_text, href = nil)
-    href ||= link_text
-    %(<a href="#{href}">#{link_text}</a>)
-  end
 end

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "active_support/all"
+
+class RailsTest < Minitest::Test
+  def test_links_with_html_safe
+    # active support messes with gsub
+    text = "http://x.x/"
+    assert_equal generate_result(text), Anchored::Linker.auto_link(text.html_safe)
+  end
+
+  def test_plain_with_html_safe
+    [" ", "hello", "<a>wat</a>...", "<a href='#'>wat.</a>"].each do |text|
+      assert_equal text, Anchored::Linker.auto_link(text.html_safe)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,10 @@
 require "minitest/autorun"
 require "anchored"
 require "byebug" if ENV["BYEBUG"]
+
+class Minitest::Test
+  def generate_result(link_text, href = nil)
+    href ||= link_text
+    %(<a href="#{href}">#{link_text}</a>)
+  end
+end


### PR DESCRIPTION
Ignore "safe" designations on strings, since #auto_link alters the string